### PR TITLE
Update the tabbing on the config.yaml file

### DIFF
--- a/example-function/config.yaml
+++ b/example-function/config.yaml
@@ -1,3 +1,3 @@
 SecretManagers:
-– secrets:
-  – secret_now
+  - secrets:
+    - secret_now


### PR DESCRIPTION
The spacing/tabbing was wrong on the yaml file which was causing the example to not work (unable to retrieve the secrets from the secret manager). Updated to sort out the spacing issue so that the example is functional.